### PR TITLE
fix: resolve integration test failures in CI

### DIFF
--- a/Maliev.InvoiceService.Api/appsettings.Testing.json
+++ b/Maliev.InvoiceService.Api/appsettings.Testing.json
@@ -1,0 +1,20 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning"
+      }
+    }
+  },
+  "ConnectionStrings": {
+    "InvoiceDbContext": "Server=localhost;Port=5432;Database=invoice_service_test;User Id=postgres;Password=postgres;"
+  },
+  "Redis": {
+    "Configuration": ""
+  },
+  "RabbitMQ": {
+    "Enabled": false
+  }
+}

--- a/Maliev.InvoiceService.Tests/Fixtures/TestDatabaseFixture.cs
+++ b/Maliev.InvoiceService.Tests/Fixtures/TestDatabaseFixture.cs
@@ -52,8 +52,9 @@ public class TestDatabaseFixture : IAsyncLifetime
         // TRUNCATE is faster and cleaner for test cleanup
         await context.Database.ExecuteSqlRawAsync(@"
             TRUNCATE TABLE audit_logs CASCADE;
-            TRUNCATE TABLE invoice_payments CASCADE;
+            TRUNCATE TABLE invoice_payment_allocations CASCADE;
             TRUNCATE TABLE invoice_lines CASCADE;
+            TRUNCATE TABLE file_references CASCADE;
             TRUNCATE TABLE invoices CASCADE;
             TRUNCATE TABLE payments CASCADE;
         ");

--- a/Maliev.InvoiceService.Tests/Integration/PaymentLinkingTests.cs
+++ b/Maliev.InvoiceService.Tests/Integration/PaymentLinkingTests.cs
@@ -98,7 +98,7 @@ public class PaymentLinkingTests : IAsyncLifetime
         var updatedInvoice = await linkResponse.Content.ReadFromJsonAsync<InvoiceResponse>();
 
         updatedInvoice.Should().NotBeNull();
-        updatedInvoice!.Status.Should().Be("Paid");
+        updatedInvoice!.Status.Should().Be("FullyPaid");
     }
 
     [Fact]
@@ -146,7 +146,7 @@ public class PaymentLinkingTests : IAsyncLifetime
         var updatedInvoice = await linkResponse.Content.ReadFromJsonAsync<InvoiceResponse>();
 
         updatedInvoice.Should().NotBeNull();
-        updatedInvoice!.Status.Should().Be("Paid");
+        updatedInvoice!.Status.Should().Be("FullyPaid");
     }
 
     private async Task<Guid> CreateAndFinalizeInvoiceAsync(decimal grandTotal)


### PR DESCRIPTION
## Summary
Fixes all integration test failures in CI workflow (80/80 tests now passing).

## Changes

### 1. Add appsettings.Testing.json
- Disables RabbitMQ in Testing environment to prevent `UriFormatException`
- Configures minimal settings for integration tests
- Resolves the root cause of test initialization failures

### 2. Update TestDatabaseFixture
- Replace obsolete `invoice_payments` table with `invoice_payment_allocations`
- Add `file_references` table to truncation list
- Aligns with latest database schema from `RemoveInvoicePaymentEntity` migration

### 3. Fix PaymentLinkingTests assertions
- Update expected status from `"Paid"` to `"FullyPaid"`
- Aligns with actual payment status enum values in codebase

## Test Results
✅ Local: 80/80 tests passing
✅ Build: 0 warnings, 0 errors

## Root Cause Analysis
The CI failures were caused by:
1. **RabbitMQ Configuration**: Tests ran in "Testing" environment but no appsettings.Testing.json existed, causing RabbitMQ to default to `Enabled: true` with invalid/empty host settings
2. **Schema Mismatch**: Test cleanup tried to truncate `invoice_payments` table that was removed in a recent migration
3. **Status Value Mismatch**: Tests expected old status value instead of updated enum value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>