### PR TITLE
fix: resolve Dockerfile publish step failure

### DIFF
--- a/Maliev.InvoiceService.Api/Dockerfile
+++ b/Maliev.InvoiceService.Api/Dockerfile
@@ -19,8 +19,7 @@ COPY . .
 
 # Build and publish
 WORKDIR /src/Maliev.InvoiceService.Api
-RUN dotnet build -c Release -o /app/build --no-restore
-RUN dotnet publish -c Release -o /app/publish --no-restore --no-build /p:UseAppHost=false
+RUN dotnet publish -c Release -o /app/publish --no-restore /p:UseAppHost=false
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime


### PR DESCRIPTION
## Summary
Fixes Docker build failure in CI workflow by simplifying the Dockerfile build process.

## Issue
The CI workflow was failing at the "Build and push Docker image" step with error:
```
error MSB3030: Could not copy the file "bin/Release/net10.0/Maliev.InvoiceService.Api.runtimeconfig.json" because it was not found.
```

## Root Cause
The Dockerfile had separate `dotnet build` and `dotnet publish` commands with mismatched output paths:
- `dotnet build -c Release -o /app/build` → outputs to `/app/build`
- `dotnet publish -c Release --no-build` → expects files in `bin/Release/net10.0`

## Solution
Simplified to use a single `dotnet publish` command which handles both building and publishing:
```dockerfile
RUN dotnet publish -c Release -o /app/publish --no-restore /p:UseAppHost=false
```

This is more efficient and avoids path mismatch issues.

## Testing
- Docker build will be validated in CI workflow
- No changes to runtime behavior or output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>