### PR TITLE
feat: add production configuration for cluster deployment

### DIFF
--- a/Maliev.InvoiceService.Api/appsettings.Production.json
+++ b/Maliev.InvoiceService.Api/appsettings.Production.json
@@ -1,0 +1,43 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    }
+  },
+  "ConnectionStrings": {
+    "InvoiceDbContext": "<connection-string-from-secrets>"
+  },
+  "Redis": {
+    "Configuration": ""
+  },
+  "ExternalServices": {
+    "CurrencyService": {
+      "BaseUrl": "http://maliev-currency-service:8080",
+      "TimeoutSeconds": 10
+    },
+    "QuotationService": {
+      "BaseUrl": "http://maliev-quotation-service:8080",
+      "TimeoutSeconds": 10
+    },
+    "PaymentService": {
+      "BaseUrl": "http://maliev-payment-service:8080",
+      "TimeoutSeconds": 10
+    },
+    "PdfService": {
+      "BaseUrl": "http://maliev-pdf-service:8080",
+      "TimeoutSeconds": 30
+    }
+  },
+  "RabbitMQ": {
+    "Enabled": false
+  },
+  "JwtSettings": {
+    "PublicKeyBase64": "<jwt-public-key-from-secrets>"
+  }
+}


### PR DESCRIPTION
## Summary
Adds production configuration to fix unhealthy pod status in the cluster by disabling RabbitMQ and making Redis optional.

## Issue
The Invoice Service was deployed to the development cluster but showing unhealthy status because:
1. **RabbitMQ not available** - Service defaulted to `RabbitMQ:Enabled=true` and tried to connect, causing startup failures
2. **Redis configuration** - While Redis health check was already gracefully degrading, production configuration wasn't explicit

## Solution

### appsettings.Production.json Created
```json
{
  "Redis": {
    "Configuration": ""  // Empty = use in-memory fallback
  },
  "RabbitMQ": {
    "Enabled": false  // Disable RabbitMQ, use in-memory MassTransit
  },
  "ExternalServices": {
    // Configured for Kubernetes DNS
    "CurrencyService": "http://maliev-currency-service:8080",
    "QuotationService": "http://maliev-quotation-service:8080",
    "PaymentService": "http://maliev-payment-service:8080",
    "PdfService": "http://maliev-pdf-service:8080"
  }
}
```

## Infrastructure Dependencies

### Required
- ✅ **PostgreSQL Database** - Readiness probe fails without it (503)

### Optional
- 🟡 **Redis** - Falls back to in-memory distributed cache, readiness probe shows Degraded but still healthy (200)
- 🟡 **RabbitMQ** - Now disabled by default, uses in-memory MassTransit for development

## Health Check Behavior

| Component | Status | Readiness Probe | Liveness Probe |
|-----------|--------|-----------------|----------------|
| Database Down | Unhealthy | 503 Service Unavailable | 200 OK |
| Redis Down | Degraded | 200 OK (degraded) | 200 OK |
| RabbitMQ Disabled | Healthy | 200 OK | 200 OK |

## Testing

Service will now:
1. Start successfully without RabbitMQ
2. Run with in-memory cache if Redis unavailable
3. Pass readiness checks with only PostgreSQL available
4. Maintain full functionality for invoice management

## API Documentation Updated

The `API specs.md` (parent repository) has been updated with complete Invoice Service documentation including:
- Deployment status and URLs
- All 16 API endpoints with full specifications
- Health check and metrics endpoints
- Infrastructure requirements
- Configuration details

## Next Steps

After this merges, the service should:
1. Show healthy status in Kubernetes
2. Be accessible at `http://maliev-invoice-service:8080/invoices`
3. API docs available at `/invoices/scalar/v1`
4. Metrics at `/invoices/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>