### PR TITLE
feat: enable Redis and RabbitMQ infrastructure

### DIFF
--- a/Maliev.InvoiceService.Api/appsettings.Production.json
+++ b/Maliev.InvoiceService.Api/appsettings.Production.json
@@ -14,7 +14,7 @@
     "InvoiceDbContext": "<connection-string-from-secrets>"
   },
   "Redis": {
-    "Configuration": ""
+    "Configuration": "redis.maliev-infra.svc.cluster.local:6379"
   },
   "ExternalServices": {
     "CurrencyService": {
@@ -35,7 +35,12 @@
     }
   },
   "RabbitMQ": {
-    "Enabled": false
+    "Enabled": true,
+    "Host": "rabbitmq.maliev-infra.svc.cluster.local",
+    "Port": 5672,
+    "Username": "maliev",
+    "Password": "maliev123",
+    "VirtualHost": "/"
   },
   "JwtSettings": {
     "PublicKeyBase64": "<jwt-public-key-from-secrets>"


### PR DESCRIPTION
## Summary

Updates production configuration to enable Redis and RabbitMQ infrastructure that is now available in the cluster.

## Changes

### appsettings.Production.json

**Redis Configuration:**
- **Before**: `"Configuration": ""` (in-memory fallback)
- **After**: `"Configuration": "redis.maliev-infra.svc.cluster.local:6379"`
- **Impact**: Enables distributed caching across service instances

**RabbitMQ Configuration:**
- **Before**: `"Enabled": false` (in-memory MassTransit)
- **After**: 
  ```json
  {
    "Enabled": true,
    "Host": "rabbitmq.maliev-infra.svc.cluster.local",
    "Port": 5672,
    "Username": "maliev",
    "Password": "maliev123",
    "VirtualHost": "/"
  }
  ```
- **Impact**: Enables event-driven architecture and payment event consumption

## Dependencies

This PR requires infrastructure to be deployed first:
- ✅ **GitOps PR**: https://github.com/MALIEV-Co-Ltd/maliev-gitops/pull/50
- Must deploy Redis and RabbitMQ to `maliev-infra` namespace before merging this PR

## Deployment Order

1. **First**: Merge and deploy maliev-gitops#50 (infrastructure)
2. **Second**: Merge and deploy this PR (service configuration)

## Benefits

### Redis Distributed Cache
- Enables horizontal scaling with shared state
- Improves performance with distributed caching
- Reduces database load

### RabbitMQ Event-Driven Architecture
- Consumes payment events from Payment Service
- Automatically links payments to invoices
- Decouples services via asynchronous messaging

## Health Check Behavior

With infrastructure available:
- **Liveness**: Always 200 OK
- **Readiness**: 
  - 200 OK (Healthy) - all components available
  - 200 OK (Degraded) - Redis unavailable (falls back to in-memory)
  - 503 (Unhealthy) - Database unavailable

## Testing

After deployment:
1. Verify Redis connection in logs
2. Verify RabbitMQ consumer registration in logs
3. Create a payment in Payment Service
4. Verify invoice status updates automatically

## Related PRs

- Infrastructure: maliev-gitops#50
- Previous config: #11 (merged - disabled RabbitMQ)

## Notes

- Environment variables in GitOps deployment override appsettings.json values
- Both development and production environments configured to use infrastructure
- Credentials are placeholder - should be managed via External Secrets in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)