### PR TITLE
chore: Standardize CI workflow PR titles and bodies

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -73,11 +73,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
           PR_BODY: |
-            Automated deployment of invoice-service to development environment.
+            Automated GitOps Update
 
-            Commit: ${{ github.sha }}
+            - **Service**: InvoiceService
+            - **Environment**: Development
+            - **Image Tag**: ${{ github.sha }}
+            - **Source Branch**: ${{ github.ref_name }}
+            - **Commit**: ${{ github.sha }}
+
+            Updates maliev-invoice-service image in development overlay.
+            This PR was automatically created by GitHub Actions.
+            Once merged, ArgoCD will automatically sync the changes to the maliev-dev namespace.
+
             Triggered by: ${{ github.actor }}
             Workflow: ${{ github.workflow }}
+            Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           cd maliev-gitops
           git config --global user.name 'github-actions[bot]'
@@ -94,8 +104,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update invoice-service image to ${{ github.sha }}"
+          git commit -m "chore(dev): Update InvoiceService image to ${{ github.sha }}"
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create             --title "Deploy invoice-service ${{ github.sha }} to development"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create \
+            --title "chore(dev): Update invoice-service" \
+            --body "$PR_BODY" \
+            --base main \
+            --head $BRANCH_NAME \
+            --repo MALIEV-Co-Ltd/maliev-gitops

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -74,13 +74,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
           PR_BODY: |
-            Automated deployment of invoice-service to production environment.
+            Automated GitOps Update - **PRODUCTION**
 
-            **PRODUCTION DEPLOYMENT** - Please review carefully before merging.
+            - **Service**: InvoiceService
+            - **Environment**: Production
+            - **Image Tag**: ${{ github.sha }}
+            - **Source Branch**: ${{ github.ref_name }}
+            - **Commit**: ${{ github.sha }}
 
-            Commit: ${{ github.sha }}
+            Updates maliev-invoice-service image in production overlay.
+            **WARNING**: This is a production deployment and should be reviewed before merging.
+            This PR was automatically created by GitHub Actions.
+            Once merged, ArgoCD will automatically sync the changes to the maliev-prod namespace.
+
             Triggered by: ${{ github.actor }}
             Workflow: ${{ github.workflow }}
+            Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           cd maliev-gitops
           git config --global user.name 'github-actions[bot]'
@@ -97,8 +106,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update invoice-service image to ${{ github.sha }}"
+          git commit -m "chore(prod): Update InvoiceService image to ${{ github.sha }}"
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create             --title "Deploy invoice-service ${{ github.sha }} to production"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create \
+            --title "chore(prod): Update invoice-service" \
+            --body "$PR_BODY" \
+            --base main \
+            --head $BRANCH_NAME \
+            --repo MALIEV-Co-Ltd/maliev-gitops

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -80,12 +80,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
           PR_BODY: |
-            Automated deployment of invoice-service to staging environment.
+            Automated GitOps Update
 
-            Release: $RELEASE_VERSION
-            Tag: ${{ github.ref }}
+            - **Service**: InvoiceService
+            - **Environment**: Staging
+            - **Release**: ${{ github.ref_name }}
+            - **Image Tag**: ${{ github.ref_name }}
+            - **Commit**: ${{ github.sha }}
+
+            Updates maliev-invoice-service image in staging overlay.
+            This PR was automatically created by GitHub Actions.
+            Once merged, ArgoCD will automatically sync the changes to the maliev-staging namespace.
+
             Triggered by: ${{ github.actor }}
             Workflow: ${{ github.workflow }}
+            Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           cd maliev-gitops
           git config --global user.name 'github-actions[bot]'
@@ -105,12 +114,12 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update invoice-service image to $RELEASE_VERSION"
+          git commit -m "chore(staging): Update InvoiceService image to $RELEASE_VERSION"
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
           gh pr create \
-            --title "Deploy invoice-service $RELEASE_VERSION to staging" \
+            --title "chore(staging): Update invoice-service" \
             --body "$PR_BODY" \
             --base main \
             --head $BRANCH_NAME \


### PR DESCRIPTION
This PR standardizes the CI workflows across the service to use consistent branch-aware PR titles and detailed, multiline PR bodies for better readability and traceability in GitOps updates.

Changes:
- Standardized PR titles to \chore(<env>): Update <service-name>\
- Implemented multiline PR bodies with service, environment, image tag, and workflow details.
- Added production warning for main branch deployments.