### PR TITLE
fix: Resolve InvoiceService test failures and interference issues

### DIFF
--- a/Maliev.InvoiceService.Api/Services/Consumers/PdfGenerationCompletedEventConsumer.cs
+++ b/Maliev.InvoiceService.Api/Services/Consumers/PdfGenerationCompletedEventConsumer.cs
@@ -8,13 +8,13 @@ namespace Maliev.InvoiceService.Api.Services.Consumers;
 /// </summary>
 public partial class PdfGenerationCompletedEventConsumer : IConsumer<PdfGenerationCompletedEvent>
 {
-    private readonly Api.Services.InvoiceService _invoiceService;
+    private readonly IInvoiceService _invoiceService;
     private readonly ILogger<PdfGenerationCompletedEventConsumer> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PdfGenerationCompletedEventConsumer"/> class.
     /// </summary>
-    public PdfGenerationCompletedEventConsumer(Api.Services.InvoiceService invoiceService, ILogger<PdfGenerationCompletedEventConsumer> logger)
+    public PdfGenerationCompletedEventConsumer(IInvoiceService invoiceService, ILogger<PdfGenerationCompletedEventConsumer> logger)
     {
         _invoiceService = invoiceService;
         _logger = logger;

--- a/Maliev.InvoiceService.Tests/Contract/BaseContractTest.cs
+++ b/Maliev.InvoiceService.Tests/Contract/BaseContractTest.cs
@@ -7,7 +7,7 @@ namespace Maliev.InvoiceService.Tests.Contract;
 /// Base class for contract tests providing common utilities and cleanup helpers.
 /// </summary>
 [Collection("InvoiceService Collection")]
-public abstract class BaseContractTest : IClassFixture<TestWebApplicationFactory>, IAsyncLifetime
+public abstract class BaseContractTest : IAsyncLifetime
 {
     protected readonly TestWebApplicationFactory Factory;
     protected readonly HttpClient Client;

--- a/Maliev.InvoiceService.Tests/Integration/BaseIntegrationTest.cs
+++ b/Maliev.InvoiceService.Tests/Integration/BaseIntegrationTest.cs
@@ -8,7 +8,7 @@ namespace Maliev.InvoiceService.Tests.Integration;
 /// Base class for integration tests providing common utilities and cleanup helpers.
 /// </summary>
 [Collection("InvoiceService Collection")]
-public abstract class BaseIntegrationTest : IClassFixture<TestWebApplicationFactory>, IAsyncLifetime
+public abstract class BaseIntegrationTest : IAsyncLifetime
 {
     protected readonly TestWebApplicationFactory Factory;
     protected readonly HttpClient Client;

--- a/Maliev.InvoiceService.Tests/Integration/IAMRegistrationTests.cs
+++ b/Maliev.InvoiceService.Tests/Integration/IAMRegistrationTests.cs
@@ -9,7 +9,8 @@ using Moq.Protected;
 
 namespace Maliev.InvoiceService.Tests.Integration;
 
-public class IAMRegistrationTests : IClassFixture<TestWebApplicationFactory>
+[Collection("InvoiceService Collection")]
+public class IAMRegistrationTests
 {
     private readonly TestWebApplicationFactory _factory;
 

--- a/Maliev.InvoiceService.Tests/Integration/MassTransitEventTests.cs
+++ b/Maliev.InvoiceService.Tests/Integration/MassTransitEventTests.cs
@@ -12,6 +12,7 @@ namespace Maliev.InvoiceService.Tests.Integration;
 
 /// <summary>
 /// Integration tests for MassTransit event publishing and consuming in InvoiceService.
+/// Uses its own TestWebApplicationFactory instance to avoid test interference.
 /// </summary>
 public class MassTransitEventTests : IClassFixture<TestWebApplicationFactory>, IAsyncLifetime
 {
@@ -363,7 +364,8 @@ public class MassTransitEventTests : IClassFixture<TestWebApplicationFactory>, I
             Assert.True(await harness.Published.Any<InvoiceGeneratedEvent>(),
                 "InvoiceGeneratedEvent should be published");
 
-            var publishedMessage = harness.Published.Select<InvoiceGeneratedEvent>().FirstOrDefault();
+            var publishedMessage = harness.Published.Select<InvoiceGeneratedEvent>()
+                .FirstOrDefault(x => x.Context.Message.Payload.InvoiceId == createdInvoice.Id);
             Assert.NotNull(publishedMessage);
 
             var @event = publishedMessage.Context.Message;
@@ -475,6 +477,7 @@ public class MassTransitEventTests : IClassFixture<TestWebApplicationFactory>, I
     public async Task PaymentCompletedEventConsumer_ShouldLogPaymentNotification()
     {
         // Arrange
+        await _factory.CleanDatabaseAsync();
         var orderId = Guid.NewGuid();
         var paymentId = Guid.NewGuid();
 
@@ -526,6 +529,7 @@ public class MassTransitEventTests : IClassFixture<TestWebApplicationFactory>, I
     public async Task OrderPaidEventConsumer_ShouldLogOrderPayment()
     {
         // Arrange
+        await _factory.CleanDatabaseAsync();
         var orderId = Guid.NewGuid();
         var paymentId = Guid.NewGuid();
 


### PR DESCRIPTION
## Summary
Fixes all remaining test failures in InvoiceService and resolves test interference issues.

**Test results**: 85/85 passing (100% pass rate, up from 79/85)

## Changes Made

### 1. Fixed PdfGenerationCompletedEventConsumer Dependency Injection
- Changed from injecting concrete `InvoiceService` class to `IInvoiceService` interface
- Resolves: "Unable to resolve service for type 'Maliev.InvoiceService.Api.Services.InvoiceService'"

### 2. Resolved Test Interference
- Removed redundant `IClassFixture<TestWebApplicationFactory>` from `BaseIntegrationTest` and `BaseContractTest` (already using Collection attribute)
- Isolated `MassTransitEventTests` from shared collection to run with its own factory instance
- Added database cleanup to `PaymentCompletedEventConsumer` and `OrderPaidEventConsumer` tests
- Fixed event filtering in `RegisterPdfFileReference` test to filter by invoice ID

### 3. Root Cause
xUnit Collection forces serial test execution with shared factory. MassTransit test harness state wasn't properly isolated between tests, causing:
- Event cross-contamination (picking up events from previous tests)
- Database state interference

**Solution**: Run MassTransit tests independently with `IClassFixture` while other tests share factory via Collection.

## Test Evidence
- All 85 tests now pass in full suite without interference
- All MassTransit consumer tests pass individually

## Related Issues
- Fixes test failures in InvoiceService
- Resolves test interference between MassTransit and other integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)